### PR TITLE
no_jira fix mutation on frozen string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2020-08-18
+### Changed
+- fixed frozen string to reassign value instead of append
+
 ## [0.1.1] - 2020-08-18
 ### Added
 - extended activerecord dependency to '>= 4.2', '< 7'

--- a/lib/active_record/mysql/enum/mysql_adapter.rb
+++ b/lib/active_record/mysql/enum/mysql_adapter.rb
@@ -33,7 +33,7 @@ module ActiveRecord
               native = native_database_types[type]
               column_type_sql = (native || {})[:name] || 'enum'
 
-              column_type_sql << "(#{limit.map { |v| quote(v) }.join(',')})"
+              column_type_sql += "(#{limit.map { |v| quote(v) }.join(',')})"
 
               column_type_sql
             else
@@ -46,7 +46,7 @@ module ActiveRecord
               native = native_database_types[type]
               column_type_sql = (native || {})[:name] || 'enum'
 
-              column_type_sql << "(#{limit.map { |v| quote(v) }.join(',')})"
+              column_type_sql += "(#{limit.map { |v| quote(v) }.join(',')})"
 
               column_type_sql
             else

--- a/lib/active_record/mysql/enum/version.rb
+++ b/lib/active_record/mysql/enum/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module Mysql
     module Enum
-      VERSION = "0.1.1"
+      VERSION = "0.1.2"
     end
   end
 end


### PR DESCRIPTION
The `mysql_adapter.rb` file was mutating a frozen string causing a `FrozenError: can't modify frozen String`

