### PR TITLE
Fix ruby27 deprecation warning

### DIFF
--- a/lib/active_record/mysql/enum/enum_column_adapter.rb
+++ b/lib/active_record/mysql/enum/enum_column_adapter.rb
@@ -22,7 +22,7 @@ module ActiveRecord
       ActiveRecordColumnWithEnums = Enum.mysql_column_adapter
 
       module EnumColumnAdapter
-        def initialize(*)
+        def initialize(*, **)
           super
 
           if type == :enum


### PR DESCRIPTION
When run `rails db:schema:dump` with Ruby 2.7, there will be a deprecation log.
`~/.rvm/gems/ruby-2.7.1/gems/activerecord-mysql-enum-2.0.0/lib/active_record/mysql/enum/enum_column_adapter.rb:26: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`
 This PR should fix the error.