### PR TITLE
non-production: make the gem easier to use with non-rails applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - Unreleased
+### Fixed
+- Fixed a bug where the gem would only work with `Rails` and not all `ActiveRecord` projects
+
 ## [2.2.0] - 2022-07-18
 ### Added
 - Added support for Rails 6.1 and 7.0
@@ -60,6 +64,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - Renamed the gem from `enum_column3` to `activerecord-mysql-enum`
 
+[2.2.1]: https://github.com/Invoca/activerecord-mysql-enum/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Invoca/activerecord-mysql-enum/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Invoca/activerecord-mysql-enum/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/Invoca/activerecord-mysql-enum/compare/v1.0.0...v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.1] - Unreleased
-### Fixed
-- Fixed a bug where the gem would only work with `Rails` and not all `ActiveRecord` projects
+## [2.3.0] - Unreleased
+### Added
+- Added the ability for non-rails applications to use the gem by using `initialize!` in the application's bootstrapping code after ActiveRecord has been configured.
 
 ## [2.2.0] - 2022-07-18
 ### Added
@@ -64,7 +64,7 @@ Note: this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 ### Changed
 - Renamed the gem from `enum_column3` to `activerecord-mysql-enum`
 
-[2.2.1]: https://github.com/Invoca/activerecord-mysql-enum/compare/v2.2.0...v2.2.1
+[2.3.0]: https://github.com/Invoca/activerecord-mysql-enum/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/Invoca/activerecord-mysql-enum/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Invoca/activerecord-mysql-enum/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/Invoca/activerecord-mysql-enum/compare/v1.0.0...v2.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activerecord-mysql-enum (2.2.0)
+    activerecord-mysql-enum (2.2.1)
       activerecord (>= 5.2, < 7.1)
       mysql2 (>= 0.4.5, < 0.6)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activerecord-mysql-enum (2.2.1)
+    activerecord-mysql-enum (2.3.0)
       activerecord (>= 5.2, < 7.1)
       mysql2 (>= 0.4.5, < 0.6)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ which was itself a fork of a fork of Nick Pohodnya's original gem for
 Rails 3, [enum_column3](https://github.com/electronick/enum_column).
 
 ## Support
-Currently this is tested with Rails version 5.2, 6.0, 6.1, and 7.0.
+Currently this is tested with ActiveRecord version 5.2, 6.0, 6.1, and 7.0.
 
 **Supported adapters:**
 - mysql2
@@ -16,6 +16,13 @@ Currently this is tested with Rails version 5.2, 6.0, 6.1, and 7.0.
 In your `Gemfile` add the following snippet
 ```ruby
 gem 'activerecord-mysql-enum', '~> 1.0', require: 'active_record/mysql/enum'
+```
+
+### Non-Rails Application
+In order to initialize the extension in non-Rails applications, you must add the following line
+to your application's bootstrapping code after ActiveRecord has been initialized.
+```ruby
+ActiveRecord::Mysql::Enum.non_rails_initialize!
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ gem 'activerecord-mysql-enum', '~> 1.0', require: 'active_record/mysql/enum'
 ### Non-Rails Application
 In order to initialize the extension in non-Rails applications, you must add the following line
 to your application's bootstrapping code after ActiveRecord has been initialized.
+
 ```ruby
-ActiveRecord::Mysql::Enum.non_rails_initialize!
+ActiveRecord::Mysql::Enum.initialize!
 ```
 
 ## Usage

--- a/lib/active_record/mysql/enum.rb
+++ b/lib/active_record/mysql/enum.rb
@@ -4,7 +4,7 @@ module ActiveRecord
   module Mysql
     module Enum
       class << self
-        def non_rails_initialize!
+        def initialize!
           require 'active_record/mysql/enum/mysql_adapter'
           require 'active_record/mysql/enum/enum_type'
           require 'active_record/mysql/enum/enum_column_adapter'
@@ -18,7 +18,7 @@ module ActiveRecord
         class Railtie < Rails::Railtie
           initializer 'active_record-mysql-enum.initialize', :after => 'active_record.initialize_database' do |app|
             ActiveSupport.on_load :active_record do
-              ActiveRecord::Mysql::Enum.non_rails_initialize!
+              ActiveRecord::Mysql::Enum.initialize!
             end
           end
         end

--- a/lib/active_record/mysql/enum.rb
+++ b/lib/active_record/mysql/enum.rb
@@ -1,18 +1,24 @@
 # frozen_string_literal: true
 
-if defined?(::Rails::Railtie)
-  module ActiveRecord
-    module Mysql
-      module Enum
+module ActiveRecord
+  module Mysql
+    module Enum
+      class << self
+        def non_rails_initialize!
+          require 'active_record/mysql/enum/mysql_adapter'
+          require 'active_record/mysql/enum/enum_type'
+          require 'active_record/mysql/enum/enum_column_adapter'
+          require 'active_record/mysql/enum/schema_definitions'
+          require 'active_record/mysql/enum/quoting'
+          require 'active_record/mysql/enum/validations'
+        end
+      end
+
+      if defined?(::Rails::Railtie)
         class Railtie < Rails::Railtie
           initializer 'active_record-mysql-enum.initialize', :after => 'active_record.initialize_database' do |app|
             ActiveSupport.on_load :active_record do
-              require 'active_record/mysql/enum/mysql_adapter'
-              require 'active_record/mysql/enum/enum_type'
-              require 'active_record/mysql/enum/enum_column_adapter'
-              require 'active_record/mysql/enum/schema_definitions'
-              require 'active_record/mysql/enum/quoting'
-              require 'active_record/mysql/enum/validations'
+              ActiveRecord::Mysql::Enum.non_rails_initialize!
             end
           end
         end

--- a/lib/active_record/mysql/enum/mysql_adapter.rb
+++ b/lib/active_record/mysql/enum/mysql_adapter.rb
@@ -52,7 +52,7 @@ module ActiveRecord
           end
         end
 
-        if Gem::Version.new(Rails.version) < Gem::Version.new('7.0')
+        if Gem::Version.new(ActiveRecord.version) < Gem::Version.new('7.0')
           private
 
           def initialize_type_map(m = type_map)
@@ -65,7 +65,7 @@ module ActiveRecord
 
       ActiveRecordMysqlAdapter.prepend ActiveRecord::Mysql::Enum::MysqlAdapter
 
-      unless Gem::Version.new(Rails.version) < Gem::Version.new('7.0')
+      unless Gem::Version.new(ActiveRecord.version) < Gem::Version.new('7.0')
         [ActiveRecordMysqlAdapter::TYPE_MAP, ActiveRecordMysqlAdapter::TYPE_MAP_WITH_BOOLEAN].each do |m|
           Enum.register_enum_with_type_mapping(m)
         end

--- a/lib/active_record/mysql/enum/version.rb
+++ b/lib/active_record/mysql/enum/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module Mysql
     module Enum
-      VERSION = "2.2.1"
+      VERSION = "2.3.0"
     end
   end
 end

--- a/lib/active_record/mysql/enum/version.rb
+++ b/lib/active_record/mysql/enum/version.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module Mysql
     module Enum
-      VERSION = "2.2.0"
+      VERSION = "2.2.1"
     end
   end
 end

--- a/spec/unit/schema_definitions_spec.rb
+++ b/spec/unit/schema_definitions_spec.rb
@@ -5,7 +5,7 @@ describe ActiveRecord::ConnectionAdapters::TableDefinition do
 
     let(:column_name) { "enum_column_test" }
     let(:test_table_definition) do
-      if Rails::VERSION::MAJOR < 6
+      if ActiveRecord::VERSION::MAJOR < 6
         ActiveRecord::ConnectionAdapters::TableDefinition.new("test_table")
       else
         ActiveRecord::ConnectionAdapters::TableDefinition.new(ActiveRecord::Base.connection, "test_table")


### PR DESCRIPTION
Got another fix here where it's making our ActiveRecord extensions work with ActiveRecord when Rails is not in use.

## [2.2.1] - Unreleased
### Fixed
- Fixed a bug where the gem would only work with `Rails` and not all `ActiveRecord` projects